### PR TITLE
Fixes #5 - Use view_hosts instead of view_content_hosts permission

### DIFF
--- a/redhat-access/db/seeds.d/200-update-insights-roles.rb
+++ b/redhat-access/db/seeds.d/200-update-insights-roles.rb
@@ -1,11 +1,11 @@
 Role.without_auditing do
   insights_admin_role = Role.where(:name => "Access Insights Admin").first
   insights_viewer_role = Role.where(:name => "Access Insights Viewer").first
-  view_host_perm = Permission.find_by_name(:view_content_hosts)
+  view_host_perm = Permission.find_by_name(:view_hosts)
   if insights_admin_role
-    insights_admin_role.add_permissions!(:view_content_hosts) unless insights_admin_role.has_permission?(view_host_perm)
+    insights_admin_role.add_permissions!(:view_hosts) unless insights_admin_role.has_permission?(view_host_perm)
   end
   if insights_viewer_role
-    insights_viewer_role.add_permissions!(:view_content_hosts) unless insights_viewer_role.has_permission?(view_host_perm)
+    insights_viewer_role.add_permissions!(:view_hosts) unless insights_viewer_role.has_permission?(view_host_perm)
   end
 end


### PR DESCRIPTION
Katello 3.2 removed the view_content_host permission as part of
host unification.