### PR TITLE
Remove cache_sweeper

### DIFF
--- a/redhat-access/app/controllers/redhat_access/api/api_controller.rb
+++ b/redhat-access/app/controllers/redhat_access/api/api_controller.rb
@@ -7,8 +7,6 @@ module RedhatAccess
       before_filter :session_expiry, :update_activity_time
       #around_filter :set_timezone
 
-      cache_sweeper :topbar_sweeper
-
       respond_to :json
 
       def http_error_response(msg,status)


### PR DESCRIPTION
As far as I could tell, this has been removed from Foreman and leads to the following error:

```
2017-04-26 03:13:52  [app] [W] Failed running foreman-tasks daemon
 | NoMethodError: undefined method `cache_sweeper' for RedhatAccess::Api::ApiController:Class
 | Did you mean?  cache_store
 | /opt/theforeman/tfm/root/usr/share/gems/gems/redhat_access-2.0.2/app/controllers/redhat_access/api/api_controller.rb:10:in `<class:ApiController>'
 | /opt/theforeman/tfm/root/usr/share/gems/gems/redhat_access-2.0.2/app/controllers/redhat_access/api/api_controller.rb:4:in `<module:Api>'
 | /opt/theforeman/tfm/root/usr/share/gems/gems/redhat_access-2.0.2/app/controllers/redhat_access/api/api_controller.rb:3:in `<module:RedhatAccess>'
 | /opt/theforeman/tfm/root/usr/share/gems/gems/redhat_access-2.0.2/app/controllers/redhat_access/api/api_controller.rb:2:in `<top (required)>'
```