### PR TITLE
BZ#1458911 - ignore locked roles while updating

### DIFF
--- a/redhat-access/db/seeds.d/200-update-insights-roles.rb
+++ b/redhat-access/db/seeds.d/200-update-insights-roles.rb
@@ -2,10 +2,12 @@ Role.without_auditing do
   insights_admin_role = Role.where(:name => "Access Insights Admin").first
   insights_viewer_role = Role.where(:name => "Access Insights Viewer").first
   view_host_perm = Permission.find_by_name(:view_hosts)
-  if insights_admin_role
-    insights_admin_role.add_permissions!(:view_hosts) unless insights_admin_role.has_permission?(view_host_perm)
-  end
-  if insights_viewer_role
-    insights_viewer_role.add_permissions!(:view_hosts) unless insights_viewer_role.has_permission?(view_host_perm)
+  Role.ignore_locking do
+    if insights_admin_role
+      insights_admin_role.add_permissions!(:view_hosts) unless insights_admin_role.has_permission?(view_host_perm)
+    end
+    if insights_viewer_role
+      insights_viewer_role.add_permissions!(:view_hosts) unless insights_viewer_role.has_permission?(view_host_perm)
+    end
   end
 end


### PR DESCRIPTION
Please merge ASAP, this blocks https://bugzilla.redhat.com/show_bug.cgi?id=1458911 which blocks https://bugzilla.redhat.com/show_bug.cgi?id=1501414

Long term it would be better to use plugin DSL to set permissions for custom plugin roles.