### PR TITLE
Inherit migrations from proper Rails version

### DIFF
--- a/redhat-access/db/migrate/20141204161152_create_redhat_access_telemetry_proxy_credentials.rb
+++ b/redhat-access/db/migrate/20141204161152_create_redhat_access_telemetry_proxy_credentials.rb
@@ -1,4 +1,4 @@
-class CreateRedhatAccessTelemetryProxyCredentials < ActiveRecord::Migration
+class CreateRedhatAccessTelemetryProxyCredentials < ActiveRecord::Migration[4.2]
   def change
     create_table :redhat_access_telemetry_proxy_credentials do |t|
       t.string :username

--- a/redhat-access/db/migrate/20150319153744_create_redhat_access_telemetry_configurations.rb
+++ b/redhat-access/db/migrate/20150319153744_create_redhat_access_telemetry_configurations.rb
@@ -1,4 +1,4 @@
-class CreateRedhatAccessTelemetryConfigurations < ActiveRecord::Migration
+class CreateRedhatAccessTelemetryConfigurations < ActiveRecord::Migration[4.2]
   def change
     create_table :redhat_access_telemetry_configurations do |t|
       t.string :portal_user

--- a/redhat-access/db/migrate/20160425175501_add_email_to_telemetry_configurations.rb
+++ b/redhat-access/db/migrate/20160425175501_add_email_to_telemetry_configurations.rb
@@ -1,4 +1,4 @@
-class AddEmailToTelemetryConfigurations < ActiveRecord::Migration
+class AddEmailToTelemetryConfigurations < ActiveRecord::Migration[4.2]
   def change
     add_column :redhat_access_telemetry_configurations, :email, :string
   end


### PR DESCRIPTION
Foreman 1.17 uses Rails 5.1, and this version requires the migrations to
inherit from a more specific Migration class. Without this change the
migrations cannot run in Rails 5.1