### PR TITLE
Rails 5 compat - before_filter -> before_action

### DIFF
--- a/redhat-access/app/controllers/redhat_access/api/api_controller.rb
+++ b/redhat-access/app/controllers/redhat_access/api/api_controller.rb
@@ -2,10 +2,10 @@ require_dependency "redhat_access/application_controller"
 module RedhatAccess
   module Api
     class ApiController < ApplicationController
-      #skip_before_filter :verify_authenticity_token, :unless => :protect_api_from_forgery?
-      #before_filter :set_default_response_format, :authorize, :add_version_header, :set_gettext_locale
-      before_filter :session_expiry, :update_activity_time
-      #around_filter :set_timezone
+      #skip_before_action :verify_authenticity_token, :unless => :protect_api_from_forgery?
+      #before_action :set_default_response_format, :authorize, :add_version_header, :set_gettext_locale
+      before_action :session_expiry, :update_activity_time
+      #around_action :set_timezone
 
       respond_to :json
 

--- a/redhat-access/app/controllers/redhat_access/api/machine_telemetry_api_controller.rb
+++ b/redhat-access/app/controllers/redhat_access/api/machine_telemetry_api_controller.rb
@@ -7,13 +7,13 @@ module RedhatAccess
   module Api
     class MachineTelemetryApiController < TelemetryApiController
 
-      skip_before_filter :authorize
-      skip_before_filter :require_login
-      skip_before_filter :session_expiry
-      skip_before_filter :verify_authenticity_token
-      skip_before_filter :check_telemetry_enabled
-      before_filter :telemetry_auth
-      before_filter :ensure_telemetry_enabled, :only => [:proxy, :proxy_upload]
+      skip_before_action :authorize
+      skip_before_action :require_login
+      skip_before_action :session_expiry
+      skip_before_action :verify_authenticity_token
+      skip_before_action :check_telemetry_enabled
+      before_action :telemetry_auth
+      before_action :ensure_telemetry_enabled, :only => [:proxy, :proxy_upload]
 
       def telemetry_auth
         authenticate_client

--- a/redhat-access/app/controllers/redhat_access/api/telemetry_api_controller.rb
+++ b/redhat-access/app/controllers/redhat_access/api/telemetry_api_controller.rb
@@ -11,7 +11,7 @@ module RedhatAccess
 
 
 
-      before_filter :check_telemetry_enabled, :only => [:proxy]
+      before_action :check_telemetry_enabled, :only => [:proxy]
 
 
       def action_permission
@@ -54,7 +54,7 @@ module RedhatAccess
         machines = get_content_hosts(current_organization)
         if machines.empty?
           machines = ['NULL_SET']
-        end 
+        end
         machines.sort
       end
 


### PR DESCRIPTION
The syntax changed in a way that's not backwards-compatible anymore.
Without this change we get an error

undefined method `before_filter' for
RedhatAccess::Api::ApiController:Class