### PR TITLE
Allow plan_id to be a searchable field on Host

### DIFF
--- a/redhat-access/app/models/redhat_access/concerns/host_managed_extensions.rb
+++ b/redhat-access/app/models/redhat_access/concerns/host_managed_extensions.rb
@@ -1,0 +1,23 @@
+module RedhatAccess
+  module Concerns
+    module HostManagedExtensions
+      extend ActiveSupport::Concern
+      included do
+        scoped_search :on => :plan_id, :complete_enabled => false,
+          :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER,
+          :ext_method => :search_by_plan_id
+      end
+
+      module ClassMethods
+        def search_by_plan_id(key, operator, value)
+          insights_plan_runner = ForemanAnsible::InsightsPlanRunner.new(Organization.current, value.to_i)
+          hostname_rules_relation = insights_plan_runner.hostname_rules(insights_plan_runner.playbook)
+          hosts = hostname_rules_relation.keys.map do |hostname|
+            Host::Managed.find_by(:name => hostname).id
+          end
+          { :conditions => " hosts.id IN(#{hosts.join(',')})" }
+        end
+      end
+    end
+  end
+end

--- a/redhat-access/lib/redhat_access/engine.rb
+++ b/redhat-access/lib/redhat_access/engine.rb
@@ -230,6 +230,7 @@ module RedhatAccess
 
     config.to_prepare do
       ::Organization.send :include, RedhatAccess::Concerns::OrganizationExtensions
+      ::Host::Managed.send :include, RedhatAccess::Concerns::HostManagedExtensions
     end
   end
 end


### PR DESCRIPTION
This introduces a feature to use `plan_id` in the search box for hosts. 
Aside from being able to find hosts for a plan ID, which is nice, this can be used in the Remote Execution search query, so that Remote Execution knows which hosts belong to a plan ID and runs anything against these servers.  

![screenshot from 2018-02-22 19-02-25](https://user-images.githubusercontent.com/598891/36555662-efa12694-1802-11e8-8593-49a005c7736c.png)
