### PR TITLE
Shorten index length

### DIFF
--- a/redhat-access/db/migrate/20150319153744_create_redhat_access_telemetry_configurations.rb
+++ b/redhat-access/db/migrate/20150319153744_create_redhat_access_telemetry_configurations.rb
@@ -8,6 +8,6 @@ class CreateRedhatAccessTelemetryConfigurations < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :redhat_access_telemetry_configurations, :organization_id
+    add_index :redhat_access_telemetry_configurations, :organization_id, :name => 'ratc_organization_id'
   end
 end


### PR DESCRIPTION
this seems to be problem only on some dbs, we hit that during packaging

```
== 20141204161152 CreateRedhatAccessTelemetryProxyCredentials: migrated (0.0008s) 
== 20150319153744 CreateRedhatAccessTelemetryConfigurations: migrating ========
-- adapter_name()
   -> 0.0000s
-- adapter_name()
   -> 0.0000s
-- create_table(:redhat_access_telemetry_configurations, {:id=>:integer})
   -> 0.0007s
-- add_index(:redhat_access_telemetry_configurations, :organization_id)
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:
Index name 'index_redhat_access_telemetry_configurations_on_organization_id' on table 'redhat_access_telemetry_configurations' is too long; the limit is 62 characters
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/schema_statements.rb:1300:in `validate_index_length!'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/schema_statements.rb:1153:in `add_index_options'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/schema_statements.rb:724:in `add_index'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:849:in `block in method_missing'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:818:in `block in say_with_time'
/opt/rh/rh-ruby24/root/usr/share/ruby/benchmark.rb:293:in `measure'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:818:in `say_with_time'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:838:in `method_missing'
/builddir/build/BUILDROOT/tfm-rubygem-redhat_access-2.1.0-1.fm1_18.el7.noarch/opt/theforeman/tfm/root/usr/share/gems/gems/redhat_access-2.1.0/db/migrate/20150319153744_create_redhat_access_telemetry_configurations.rb:11:in `change'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:792:in `exec_migration'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:776:in `block (2 levels) in migrate'
/opt/rh/rh-ruby24/root/usr/share/ruby/benchmark.rb:293:in `measure'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:775:in `block in migrate'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:408:in `with_connection'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:774:in `migrate'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:953:in `migrate'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1230:in `block in execute_migration_in_transaction'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1298:in `block in ddl_transaction'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:235:in `block in transaction'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/transaction.rb:194:in `block in within_new_transaction'
/opt/rh/rh-ruby24/root/usr/share/ruby/monitor.rb:214:in `mon_synchronize'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/transaction.rb:191:in `within_new_transaction'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:235:in `transaction'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/transactions.rb:210:in `transaction'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1298:in `ddl_transaction'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1229:in `execute_migration_in_transaction'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1201:in `block in migrate_without_lock'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1200:in `each'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1200:in `migrate_without_lock'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1150:in `migrate'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:1007:in `up'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/migration.rb:985:in `migrate'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/tasks/database_tasks.rb:171:in `migrate'
/opt/rh/tfm-ror51/root/usr/share/gems/gems/activerecord-5.1.4/lib/active_record/railties/databases.rake:58:in `block (2 levels) in <top (required)>'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/task.rb:250:in `block in execute'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/task.rb:250:in `each'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/task.rb:250:in `execute'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/task.rb:194:in `block in invoke_with_call_chain'
/opt/rh/rh-ruby24/root/usr/share/ruby/monitor.rb:214:in `mon_synchronize'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/task.rb:187:in `invoke_with_call_chain'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/task.rb:180:in `invoke'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:152:in `invoke_task'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:108:in `block (2 levels) in top_level'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:108:in `each'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:108:in `block in top_level'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:117:in `run_with_threads'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:102:in `top_level'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:80:in `block in run'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:178:in `standard_exception_handling'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/lib/rake/application.rb:77:in `run'
/opt/rh/rh-ruby24/root/usr/share/gems/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/opt/rh/rh-ruby24/root/usr/bin/rake:22:in `load'
/opt/rh/rh-ruby24/root/usr/bin/rake:22:in `<main>'
ArgumentError: Index name 'index_redhat_access_telemetry_configurations_on_organization_id' on table 'redhat_access_telemetry_
```