### PR TITLE
Fixes #32 - insights playbook run PG error fixed

### DIFF
--- a/redhat-access/app/models/redhat_access/concerns/host_managed_extensions.rb
+++ b/redhat-access/app/models/redhat_access/concerns/host_managed_extensions.rb
@@ -12,7 +12,7 @@ module RedhatAccess
         def search_by_plan_id(key, operator, value)
           insights_plan_runner = ForemanAnsible::InsightsPlanRunner.new(Organization.current, value.to_i)
           hostname_rules_relation = insights_plan_runner.hostname_rules(insights_plan_runner.playbook)
-          host_ids = Host::Managed.where(:name => hostname_rules_relation.keys).pluck(&:id)
+          host_ids = Host::Managed.where(:name => hostname_rules_relation.keys).pluck(:id)
           { :conditions => " hosts.id IN(#{host_ids.join(',')})" }
         end
       end


### PR DESCRIPTION
https://github.com/redhataccess/foreman-plugin/blob/abfbf138bd77026a6e043719eea5312504d0bc78/redhat-access/app/models/redhat_access/concerns/host_managed_extensions.rb#L15

when trying to pluck the Host ID with the current syntax implemented, it returns the full array hash causing the insights run to fail.