### PR TITLE
BZ1642194 - Proxied upload timeout

### DIFF
--- a/redhat-access/app/controllers/redhat_access/api/machine_telemetry_api_controller.rb
+++ b/redhat-access/app/controllers/redhat_access/api/machine_telemetry_api_controller.rb
@@ -36,7 +36,7 @@ module RedhatAccess
 
       def api_connection_test
         client = get_api_client
-        res = client.call_tapi('GET', '/', nil, nil, nil)
+        res = client.call_tapi('GET', '/', nil, nil, {timeout: get_tapi_timeout})
         Rails.logger.debug(res[:data])
         render status: res[:code], json: {}
       end
@@ -61,7 +61,7 @@ module RedhatAccess
         
         client = get_api_client
         Rails.logger.debug("Proxy upload original_payload : #{original_payload}")
-        res = client.call_tapi(original_method, URI.escape(resource), original_params, original_payload, nil, use_subsets)
+        res = client.call_tapi(original_method, URI.escape(resource), original_params, original_payload, {timeout: get_upload_timeout}, use_subsets)
         render status: res[:code] , json: res[:data]
       end
 

--- a/redhat-access/app/controllers/redhat_access/api/telemetry_api_controller.rb
+++ b/redhat-access/app/controllers/redhat_access/api/telemetry_api_controller.rb
@@ -65,7 +65,7 @@ module RedhatAccess
 
       def connection_status
         client = get_api_client
-        res = client.call_tapi('GET', 'me', nil, nil, nil)
+        res = client.call_tapi('GET', 'me', nil, nil, {timeout: get_tapi_timeout})
         Rails.logger.debug(res[:data])
         case res[:code]
         when 200
@@ -117,7 +117,7 @@ module RedhatAccess
         end
 
         client = get_api_client
-        res = client.call_tapi(original_method, URI.escape(resource), original_params, original_payload, nil, use_subsets)
+        res = client.call_tapi(original_method, URI.escape(resource), original_params, original_payload, {timeout: get_tapi_timeout}, use_subsets)
         #401 erros means our proxy is not configured right.
         #Change it to 502 to distinguish with local applications 401 errors
         resp_data = res[:data]

--- a/redhat-access/app/controllers/redhat_access/telemetry_configurations_controller.rb
+++ b/redhat-access/app/controllers/redhat_access/telemetry_configurations_controller.rb
@@ -19,7 +19,7 @@ module RedhatAccess
         else
           render json: {:error=>"Invalid parameters"}.to_json, status: 400
         end
-          rescue=>e
+          rescue => e
           Rails.logger.info(e)
           render json: {:error=>"Error processing update"}.to_json, status: 500
         end

--- a/redhat-access/app/services/redhat_access/telemetry/look_ups.rb
+++ b/redhat-access/app/services/redhat_access/telemetry/look_ups.rb
@@ -210,6 +210,15 @@ module RedhatAccess
         "#{get_plugin_parent_name}/#{get_plugin_parent_version};#{get_rha_plugin_name}/#{get_rha_plugin_version}"
       end
 
+      # timeout for telemetry api operations
+      def get_tapi_timeout
+        REDHAT_ACCESS_CONFIG[:telemetry_api_timeout_s] || 60
+      end
+
+      # timeout for telemetry uploads
+      def get_upload_timeout
+        REDHAT_ACCESS_CONFIG[:telemetry_upload_timeout_s] || 120
+      end
 
       def get_http_options(include_user_id = false)
         headers = {}

--- a/redhat-access/app/services/redhat_access/telemetry/messaging_service.rb
+++ b/redhat-access/app/services/redhat_access/telemetry/messaging_service.rb
@@ -164,7 +164,7 @@ module RedhatAccess
                                                         #{:branch_id => @branch_id}.merge(options[:params]),
                                                         options[:params],
                                                         options[:payload],
-                                                        nil,
+                                                        {timeout: get_tapi_timeout},
                                                         options[:use_subsets])
         if res.key?(:error)
           raise res[:error]

--- a/redhat-access/config/config.yml.example
+++ b/redhat-access/config/config.yml.example
@@ -6,7 +6,9 @@
 
 :enable_telemetry_basic_auth : false
 :telemetry_upload_host : "https://cert-api.access.redhat.com"
+# :telemetry_upload_timeout_s : 120
 :telemetry_api_host : "https://cert-api.access.redhat.com"
+# :telemetry_api_timeout_s : 60
 :telemetry_ssl_verify_peer : true
 
 :diagnostic_logs :

--- a/redhat-access/lib/redhat_access/version.rb
+++ b/redhat-access/lib/redhat_access/version.rb
@@ -1,3 +1,3 @@
 module RedhatAccess
-  VERSION = "2.2.7"
+  VERSION = "2.2.8"
 end

--- a/redhat-access/redhat_access.gemspec
+++ b/redhat-access/redhat_access.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib,vendor,public,script,ca,locale}/**/*"] + ["LICENSE.txt", "Rakefile", "README.rdoc", "redhat_access.gemspec", "Gemfile"]
   s.test_files = Dir["test/**/*"]
-  s.add_dependency "redhat_access_lib" , ">=1.1.0"
+  s.add_dependency "redhat_access_lib" , ">=1.1.5"
   s.add_dependency "angular-rails-templates", ">=0.0.4"
 
 end

--- a/redhat-access/rubygem-foreman-redhat_access.spec
+++ b/redhat-access/rubygem-foreman-redhat_access.spec
@@ -15,7 +15,7 @@
 %global scl_rake /usr/bin/%{?scl:%{scl_prefix}}rake
 
 Name: %{?scl_prefix}rubygem-foreman-%{gem_name}
-Version: 2.2.7
+Version: 2.2.8
 Release: 1%{?dist}
 Summary: Foreman engine to access Red Hat knowledge base and manage support cases.
 Group: Development/Languages
@@ -29,7 +29,7 @@ Requires: katello >= 3.4.0
 
 Requires: %{?scl_prefix_ruby}ruby(rubygems)
 Requires: %{?scl_prefix}rubygem(angular-rails-templates) >= 0.0.4
-Requires: %{?scl_prefix}rubygem-redhat_access_lib >= 1.1.0
+Requires: %{?scl_prefix}rubygem-redhat_access_lib >= 1.1.5
 Requires: redhat-access-insights-puppet >= 0.0.9
 
 
@@ -124,6 +124,9 @@ cp -pa $RPM_BUILD_DIR/%{gem_name}-%{version}/config/config.yml.example %{buildro
 
 
 %changelog*
+
+* Fir Jul 12 2019 Rex White <rexwhite@redhat.com> 2.2.8-1
+- BZ 1642194: Added config items for upload and tapi request timeouts
 
 * Thu Feb 7 2019 Rex White <rewhite@redhat.com> - 2.2.1-1
 - BZ 1656478


### PR DESCRIPTION
Uploads are now large enough to take longer than the default 60s
to complete and the proxy timed out.  Increased default timeout
for uploads to 120 seconds and added independant config
parameters for api operations and uploads.