### PR TITLE
Use branch_id instead of subsets for limiting scope of operations

### DIFF
--- a/redhat-access/app/services/redhat_access/telemetry/look_ups.rb
+++ b/redhat-access/app/services/redhat_access/telemetry/look_ups.rb
@@ -210,7 +210,6 @@ module RedhatAccess
         "#{get_plugin_parent_name}/#{get_plugin_parent_version};#{get_rha_plugin_name}/#{get_rha_plugin_version}"
       end
 
-
       def get_http_options(include_user_id = false)
         headers = {}
         if include_user_id && User.current
@@ -220,6 +219,22 @@ module RedhatAccess
          :http_proxy => get_portal_http_proxy,
          :user_agent => get_http_user_agent,
          :headers => headers}
+      end
+
+      # global use_subsets flag - defaults to false to suppress use of subsets to address scalability problems
+      # (subset and branch_id are equivalent for satellite)
+      def use_subsets?
+        REDHAT_ACCESS_CONFIG[:use_subsets] || false
+      end
+
+      # timeout for telemetry api operations
+      def get_tapi_timeout
+        REDHAT_ACCESS_CONFIG[:telemetry_api_timeout_s] || 60
+      end
+
+      # timeout for telemetry uploads
+      def get_upload_timeout
+        REDHAT_ACCESS_CONFIG[:telemetry_upload_timeout_s] || 120
       end
 
       def user_login_to_hash(login)

--- a/redhat-access/app/services/redhat_access/telemetry/portal_client.rb
+++ b/redhat-access/app/services/redhat_access/telemetry/portal_client.rb
@@ -20,6 +20,11 @@ module RedhatAccess
         @context = context
       end
 
+      # intercept call_tapi() so we can override use of subsets
+      def call_tapi(original_method, resource, original_params, original_payload, extra, use_subsets = true)
+        super(original_method, resource, original_params, original_payload, extra, use_subsets? && use_subsets)
+      end
+
       # Returns the branch id of the current org/account
       def get_branch_id
         organization = get_current_organization

--- a/redhat-access/config/config.yml.example
+++ b/redhat-access/config/config.yml.example
@@ -8,6 +8,7 @@
 :telemetry_upload_host : "https://cert-api.access.redhat.com"
 :telemetry_api_host : "https://cert-api.access.redhat.com"
 :telemetry_ssl_verify_peer : true
+:use_subsets : false
 
 :diagnostic_logs :
   - /var/log/foreman/production.log

--- a/redhat-access/config/defaults.yml
+++ b/redhat-access/config/defaults.yml
@@ -9,6 +9,8 @@
 :telemetry_api_host : "https://cert-api.access.redhat.com"
 :telemetry_ssl_verify_peer : true
 
+:use_subsets : false
+
 :diagnostic_logs :
   - /var/log/foreman/production.log
   - /var/log/foreman/delayed_job.log

--- a/redhat-access/lib/redhat_access/version.rb
+++ b/redhat-access/lib/redhat_access/version.rb
@@ -1,3 +1,3 @@
 module RedhatAccess
-  VERSION = "2.2.7"
+  VERSION = "2.2.8"
 end


### PR DESCRIPTION
I shadowed call_tapi() in portal_client.rb to intercept calls so we can use a new config variable to suppress the use of subsets.