### PR TITLE
Declare all dependencies

### DIFF
--- a/redhat-access/redhat_access.gemspec
+++ b/redhat-access/redhat_access.gemspec
@@ -19,5 +19,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
   s.add_dependency "redhat_access_lib" , ">=1.1.5"
   s.add_dependency "angular-rails-templates", ">=0.0.4"
+  s.add_dependency "foreman-tasks"
+  s.add_dependency "katello"
 
 end


### PR DESCRIPTION
Both Katello and Foreman Tasks are used and needed. By declaring them in the gemspec, we can be sure they're actually present.