### PR TITLE
BZ1611621 - fixed disconnected mode detection to permit insights in disconnected mode

### DIFF
--- a/redhat-access/app/services/redhat_access/telemetry/look_ups.rb
+++ b/redhat-access/app/services/redhat_access/telemetry/look_ups.rb
@@ -15,8 +15,7 @@ module RedhatAccess
       end
 
       def can_mask_rules(user)
-        # #TODO move this to an auth class?
-        # TODO move this to an auth class?
+        849456        # TODO move this to an auth class?
         return false if user.nil?
         return true if user.admin
         permissions = user.cached_roles.collect(&:permissions).flatten.map!(&:name)
@@ -67,7 +66,8 @@ module RedhatAccess
       def disconnected_org?(org)
         if org
           # TODO: fix hard coding
-          org.redhat_repository_url != 'https://cdn.redhat.com'
+          # disable insights if disconnected orgs aren't enabled and katello doesn't point to redhat's CDN
+          !REDHAT_ACCESS_CONFIG[:enable_insights_for_disconnected_orgs] && org.redhat_repository_url != 'https://cdn.redhat.com'
         else
           raise(RecordNotFound, 'Organization not found or invalid')
         end

--- a/redhat-access/config/config.yml.example
+++ b/redhat-access/config/config.yml.example
@@ -11,6 +11,7 @@
 # :telemetry_api_timeout_s : 60
 :telemetry_ssl_verify_peer : true
 :use_subsets : false
+:enable_insights_for_disconnected_orgs : false
 
 :diagnostic_logs :
   - /var/log/foreman/production.log

--- a/redhat-access/config/defaults.yml
+++ b/redhat-access/config/defaults.yml
@@ -9,6 +9,7 @@
 :telemetry_api_host : "https://cert-api.access.redhat.com"
 :telemetry_ssl_verify_peer : true
 
+:enable_insights_for_disconnected_orgs : false
 :use_subsets : false
 
 :diagnostic_logs :


### PR DESCRIPTION
Added a config item to enable insights when katello isn't pointed at cdn.redhat.com