### PR TITLE
Drop branch_info endpoint

### DIFF
--- a/redhat-access/app/services/redhat_access/telemetry/look_ups.rb
+++ b/redhat-access/app/services/redhat_access/telemetry/look_ups.rb
@@ -196,10 +196,6 @@ module RedhatAccess
         end
       end
 
-      def get_foreman_instance_id
-        Foreman.respond_to?(:instance_id) ? Foreman.instance_id : nil
-      end
-
       def get_portal_http_proxy
         begin
           @http_proxy_string ||=
@@ -277,11 +273,6 @@ module RedhatAccess
       # timeout for telemetry uploads
       def get_upload_timeout
         REDHAT_ACCESS_CONFIG[:telemetry_upload_timeout_s] || 120
-      end
-
-      # list of parameters to include as tags (or 'true' for all of them)
-      def get_include_parameter_tags
-        REDHAT_ACCESS_CONFIG[:include_parameter_tags] || false
       end
 
       def user_login_to_hash(login)

--- a/redhat-access/config/routes.rb
+++ b/redhat-access/config/routes.rb
@@ -13,7 +13,6 @@ RedhatAccess::Engine.routes.draw do
     get "/insights/templates/:page" => "analytics_dashboard#template"  # hack to get around angular-rails-templates bug
     scope '/r/insights' do
       get   '/',                    to: 'api/machine_telemetry_api#api_connection_test'
-      get   '/v1/branch_info',      to: 'api/machine_telemetry_api#get_branch_info'
       post  '/uploads/(:id)',       to: 'api/machine_telemetry_api#proxy_upload'
       get '/view/api/:v/me' ,   to: 'api/telemetry_api#connection_status', :constraints => {:v =>/(v[0-9]|latest)/}
       match '/view/api/:path',      to: 'api/telemetry_api#proxy', :constraints => {:path => /.*/} ,via: [:get, :post, :delete,:put, :patch]


### PR DESCRIPTION
Branch info endpoint is being moved
to foreman_rh_cloud, therefore it can
be removed.

To be merged after https://github.com/theforeman/foreman_rh_cloud/pull/325