### PR TITLE
Add /lib folder to load paths in engine.rb

### DIFF
--- a/redhat-access/lib/redhat_access/engine.rb
+++ b/redhat-access/lib/redhat_access/engine.rb
@@ -14,6 +14,8 @@ module RedhatAccess
   class Engine < ::Rails::Engine
     isolate_namespace RedhatAccess
 
+    config.eager_load_paths += Dir["#{config.root}/lib"]
+    
     initializer "redhat_access.load_app_instance_data" do |app|
       unless app.root.to_s.match root.to_s
         config.paths["db/migrate"].expanded.each do |expanded_path|


### PR DESCRIPTION
Missing `config.eager_load_paths += Dir["#{config.root}/lib"]` in `engine.rb` can cause `NameError (uninitialized constant RedhatAccess::VERSION)`

How to reproduce:
* Add `gem 'foreman_rh_cloud', path: '/home/vagrant/rh_cloud'` to `Gemfile`
* Register rhel host
* Run `insights-client --test-connection` on rhel host 

It will fail, because of:  `NameError (uninitialized constant RedhatAccess::VERSION)`

cc: @ShimShtein 